### PR TITLE
Fix optional dependencies

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1,0 +1,6 @@
+try:
+    from openai import OpenAI
+    with open("key.txt", "r", encoding="utf-8") as f:
+        client = OpenAI(api_key=f.read().strip())
+except (ImportError, FileNotFoundError):
+    client = None

--- a/handlers.py
+++ b/handlers.py
@@ -1,9 +1,21 @@
-from rich.console import Console
+try:
+    from rich.console import Console
+except ImportError:  # pragma: no cover
+    class Console:
+        def print(self, *args, **kwargs):
+            print(*args)
+
+        def input(self, prompt: str = "") -> str:
+            return input(prompt)
+
 from typing import Optional
-from models import GeneralNote, Field, Record, AddressBook, group_notes_by_tag
+from models import (
+    GeneralNote, Field, Record, AddressBook,
+    group_notes_by_tag, make_key, make_key_from_input, get_record_key
+)
 from logic import *
-from logic import input_error, help_msg, simple_match 
-from main import _client
+from logic import input_error, help_msg, simple_match
+from ai import client as _client
 
 console = Console()
 
@@ -18,32 +30,6 @@ User will send a search query in Russian, Ukrainian or English.
 Return ONLY the indices (space‑separated) of up to five notes
 that are truly relevant. If nothing fits, return an empty string.
 """
-
-def make_key(name: str, surname: str = "") -> str:
-    return f"{name} {surname}".strip().lower()
-
-
-def make_key_from_input(fullname: str) -> str:
-    parts = fullname.strip().split(maxsplit=1)
-    return make_key(*parts)
-
-
-def get_record_key(name: str, book: AddressBook) -> Optional[str]:
-    name_parts = name.strip().split(maxsplit=1)
-    if not name_parts:
-        return None
-
-    matches = [k for k in book.data if all(part.lower() in k for part in name_parts)]
-    if len(matches) == 1:
-        return matches[0]
-    elif len(matches) > 1:
-        console.print("[yellow]Multiple matches found:[/]")
-        for i, k in enumerate(matches, 1):
-            console.print(f"{i}. {k.title()}")
-        idx = console.input("Select number >>> ").strip()
-        if idx.isdigit() and 1 <= int(idx) <= len(matches):
-            return matches[int(idx) - 1]
-    return None
 
 
 @input_error

--- a/logic.py
+++ b/logic.py
@@ -2,12 +2,47 @@
 import re
 # from collections import UserDict
 from typing import Optional, List, Type #Tuple
-from rich.columns import Columns
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
+try:
+    from rich.columns import Columns
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+    HAVE_RICH = True
+except ImportError:  # pragma: no cover - fallback for minimal envs
+    HAVE_RICH = False
+
+    class Console:
+        def print(self, *args, **kwargs):
+            print(*args)
+
+        def input(self, prompt: str = "") -> str:
+            return input(prompt)
+
+    class Columns(list):
+        pass
+
+    class Panel:
+        def __init__(self, renderable, title: str = "", border_style: str = ""):
+            self.renderable = renderable
+            self.title = title
+
+        def __str__(self):
+            return f"{self.title}\n{self.renderable}"
+
+    class Table:
+        def __init__(self, *args, **kwargs):
+            self.rows = []
+
+        def add_column(self, *args, **kwargs):
+            pass
+
+        def add_row(self, *args, **kwargs):
+            self.rows.append(" | ".join(args))
+
+        def __str__(self):
+            return "\n".join(self.rows)
 import getpass
-from main import _client
+from ai import client as _client
 from models import GeneralNote, Field, Record, AddressBook
 from storage import *
 from storage import save_users

--- a/main.py
+++ b/main.py
@@ -1,19 +1,20 @@
-from openai import OpenAI
-from rich.console import Console
+# Rich is optional. Provide a very small fallback console
+try:
+    from rich.console import Console
+except ImportError:  # pragma: no cover - fallback for minimal envs
+    class Console:
+        def print(self, *args, **kwargs):
+            print(*args)
+
+        def input(self, prompt: str = "") -> str:
+            return input(prompt)
+
 from logic import *
 from handlers import *
 from storage import *
+from ai import client as _client
 
-# ────────────────────────────────────────────────────────────────────────────
-# Optional OpenAI (autocorrect & semantic search); can work without key.txt
-# ────────────────────────────────────────────────────────────────────────────
-try:
-    from openai import OpenAI
-
-    with open("key.txt", "r", encoding="utf‑8") as f:
-        _client = OpenAI(api_key=f.read().strip())
-except (ImportError, FileNotFoundError):
-    _client = None
+console = Console()
 
 def main():
     users = load_users()

--- a/models.py
+++ b/models.py
@@ -1,9 +1,40 @@
 import datetime
+import datetime
 import re
 from typing import Optional, List, Tuple, Type
 from collections import UserDict
-from handlers import *
-from handlers import get_record_key, make_key, make_key_from_input
+
+__all__ = [
+    'Field', 'Name', 'Surname', 'Address', 'Email', 'Phone', 'Birthday',
+    'Record', 'AddressBook', 'GeneralNote', 'GeneralNoteBook',
+    'get_record_key', 'make_key', 'make_key_from_input', 'group_notes_by_tag'
+]
+
+def make_key(name: str, surname: str = "") -> str:
+    return f"{name} {surname}".strip().lower()
+
+
+def make_key_from_input(fullname: str) -> str:
+    parts = fullname.strip().split(maxsplit=1)
+    return make_key(*parts)
+
+
+def get_record_key(name: str, book: 'AddressBook') -> Optional[str]:
+    name_parts = name.strip().split(maxsplit=1)
+    if not name_parts:
+        return None
+
+    matches = [k for k in book.data if all(part.lower() in k for part in name_parts)]
+    if len(matches) == 1:
+        return matches[0]
+    elif len(matches) > 1:
+        print("Multiple matches found:")
+        for i, k in enumerate(matches, 1):
+            print(f"{i}. {k.title()}")
+        idx = input("Select number >>> ").strip()
+        if idx.isdigit() and 1 <= int(idx) <= len(matches):
+            return matches[int(idx) - 1]
+    return None
 
 
 


### PR DESCRIPTION
## Summary
- add fallback console when `rich` is unavailable
- add new `ai` module to hold optional OpenAI client
- remove circular imports
- make helper functions accessible from `models`

## Testing
- `python main.py <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d48738f9c8320adf0d4b424813aa5