### PR TITLE
Fix AI search crash

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -8,6 +8,8 @@ except ImportError:  # pragma: no cover
         def input(self, prompt: str = "") -> str:
             return input(prompt)
 
+import re
+
 from typing import Optional
 from models import (
     GeneralNote, Field, Record, AddressBook,


### PR DESCRIPTION
## Summary
- fix missing `re` import used in note AI search

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4f45c51c83208ec939df65d6a474